### PR TITLE
Add keyword to be recognized by Astro's integration directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "keywords": [
     "astro",
     "astrojs",
+    "astro-component",
     "tailwind",
     "tailwindcss",
     "autoinject",


### PR DESCRIPTION
This PR **adds a keyword in `package.json`** so that the utility will be automatically recognized by and included in the Astro integrations directory (https://astro.build/integrations/) as outlined in [Astro's documentation for publishing NPM packages](https://docs.astro.build/en/reference/publish-to-npm/#packagejson-data).

That listing is entirely automated, so **if you'd like to appear there, this keyword is necessary**. If you *don't* want to be listed (or aren't ready to be listed yet) you are welcome to close this PR! (It was just easier for me to make the change needed than to file an issue explaining what is needed.)

No hard feelings if you don't want to be included and you are welcome to ignore and close this! But, I also monitor new additions every month to include in the Astro monthly blog post. So this is also the best way to find yourself in the blog post, too.

Thank you for building *for* Astro! :rocket: 
